### PR TITLE
Fix mission date reset and creation crash

### DIFF
--- a/app/assets/javascripts/missionForm.js
+++ b/app/assets/javascripts/missionForm.js
@@ -10,6 +10,7 @@ $(document).on('turbolinks:load', () => {
     widgetPositioning: {
       horizontal: 'left',
     },
+    viewDate: this.date(),
   });
   $('#mission_due_date').datetimepicker({
     locale: 'fr',
@@ -17,6 +18,7 @@ $(document).on('turbolinks:load', () => {
     widgetPositioning: {
       horizontal: 'left',
     },
+    viewDate: this.date(),
   });
 
   $('#mission_recurrent').on('change', () => {

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -81,9 +81,9 @@ class MissionsController < ApplicationController
                                  model: Mission.model_name.human
       render :show
     else
-      flash[:error] = translate "activerecord.errors.creation_fail",
+      flash[:error] = translate "activerecord.errors.messages.creation_fail",
                                 model: Mission.model_name.human
-      render :new
+      redirect_to new_mission_path
     end
   end
 

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -28,6 +28,7 @@ class Mission < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+  validates :start_date, presence: true, on: :update
   validates :min_member_count, numericality: { only_integer: true }, presence: true
   validates :max_member_count, numericality: { only_integer: true }, allow_nil: true
 

--- a/app/views/missions/_form.html.erb
+++ b/app/views/missions/_form.html.erb
@@ -50,10 +50,8 @@
           <%= f.label :due_date, Mission.human_attribute_name(:due_date) %><br />
           <%= f.text_field :due_date,
             class: "form-control form-control-lg datetimepicker-input",
-            data: {
-              toggle: "datetimepicker",
-              target: "#mission_due_date"
-            }
+            data: { toggle: "datetimepicker", target: "#mission_due_date" },
+            required: true
           %>
         </div>
       </div>

--- a/app/views/missions/_form.html.erb
+++ b/app/views/missions/_form.html.erb
@@ -40,18 +40,16 @@
           <%= f.label :start_date, Mission.human_attribute_name(:start_date) %>
           <%= f.text_field :start_date,
             class: "form-control form-control-lg datetimepicker-input",
-            data: {
-              toggle: "datetimepicker",
-              target: "#mission_start_date"
-            } %>
+            data: { toggle: "datetimepicker", target: "#mission_start_date" },
+            value: mission.start_date
+          %>
         </div>
 
         <div class="field">
           <%= f.label :due_date, Mission.human_attribute_name(:due_date) %><br />
           <%= f.text_field :due_date,
             class: "form-control form-control-lg datetimepicker-input",
-            data: { toggle: "datetimepicker", target: "#mission_due_date" },
-            required: true
+            data: { toggle: "datetimepicker", target: "#mission_due_date" }
           %>
         </div>
       </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,8 +3,8 @@ fr:
   activerecord:
     errors:
       messages:
-        creation_fail: La création du/de la %{model} a échoué
-        destroy_fail: La suppression du/de la %{model} a échoué
+        creation_fail: La création de %{model} a échoué
+        destroy_fail: La suppression de %{model} a échoué
         record_invalid: "La validation a échoué : %{errors}"
         restrict_dependent_destroy:
           has_one:
@@ -62,7 +62,7 @@ fr:
       mission:
         author: Auteur
         description: Description
-        due_date: Date et heure de fin
+        due_date: Date et heure limite
         max_member_count: Nombre maximum de participants
         min_member_count: Nombre minimum de personnes souhaitées
         name: Nom

--- a/spec/controllers/missions_controller_spec.rb
+++ b/spec/controllers/missions_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe MissionsController, type: :controller do
   let(:super_admin) { create :member, :super_admin }
   let(:mission) { create :mission }
   let(:valid_attributes) { attributes_for(:mission) }
-  let(:invalid_attributes) do { name: '' } end
 
   before { sign_in super_admin }
 
@@ -39,47 +38,32 @@ RSpec.describe MissionsController, type: :controller do
         mission.reload
       }
 
-      it "assigns @mission" do
-        expect(assigns(:mission)).to eq(mission)
-      end
-
+      it "assigns @mission" do expect(assigns(:mission)).to eq(mission) end
       it { expect(response).to render_template(:show) }
 
-      it "updates the .name attribute" do
-        expect(mission.name).to eq(valid_attributes[:name])
-      end
-
-      it "updates the .description attribute" do
-        expect(mission.description).to eq(valid_attributes[:description])
-      end
-
-      it "updates the .max_member_count attribute" do
-        expect(mission.max_member_count).to eq(valid_attributes[:max_member_count])
-      end
-
-      it "updates the .min_member_count attribute" do
-        expect(mission.min_member_count).to eq(valid_attributes[:min_member_count])
-      end
-
-      it "updates the .start_date attribute" do
-        expect(mission.start_date).to eq(valid_attributes[:start_date])
-      end
-
-      it "updates the .due_date attribute" do
-        expect(mission.due_date).to eq(valid_attributes[:due_date])
+      %i[
+        name description max_member_count min_member_count start_date due_date
+      ].each do |attribute|
+        it "updates the :#{attribute} attribute" do
+          expect(mission.send(attribute)).to eq(valid_attributes[attribute])
+        end
       end
     end
 
     context 'with invalid params' do
-      it 'redirects to the edit form' do
-        put :update, params: { id: mission.id, mission: invalid_attributes }
-        expect(response).to render_template(:edit)
+      def invalid_request(invalid_attribute)
+        put :update, params: { id: mission.id, mission: { "#{invalid_attribute}": '' } }
       end
 
-      it 'does not change the mission' do
-        expect{
-          put :update, params: { id: mission.id, mission: invalid_attributes }
-        }.not_to change(mission.reload.name, :methods)
+      %w(name description min_member_count start_date).each do |attribute|
+        it 'redirects to the edit form' do
+          invalid_request(attribute)
+          expect(response).to render_template(:edit)
+        end
+
+        it "does not change the mission :#{attribute} attribute" do
+          expect{ invalid_request(attribute) }.not_to(change { mission.reload.send(attribute) })
+        end
       end
     end
   end


### PR DESCRIPTION
* Events were disappearing from calendar on update when attributes other than dates were updated.
* Mission creation fail was leaving the model instance in a weird state, that caused a crash with `:render new` fallback