### PR TITLE
Modify members groups enum names

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -63,8 +63,18 @@ class Member < ApplicationRecord
 
   enum role: { member: 0, admin: 1, super_admin: 2 }
   enum group: {
-    collective: 1, management: 2, communication: 3,
-    maintenance_supply: 4, community_projects: 5, it: 6
+    welcome: 1,
+    financial_management: 2,
+    members_management: 3,
+    core: 4,
+    schedule: 5,
+    diy: 6,
+    internal_culture: 7,
+    local_suppliers: 8,
+    other_suppliers: 9,
+    supply: 10,
+    orders_management: 11,
+    it: 12
   }
   enum cash_register_proficiency: { untrained: 0, beginner: 1, proficient: 2 }
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -52,11 +52,17 @@ fr:
         group: Groupe
         groups:
           no_group: Aucun
-          collective: Collectif
-          management: Gestion
-          communication: Communication
-          maintenance_supply: Maintenance/approvisionnement
-          community_projects: Vie associative
+          welcome: Accueil
+          financial_management: Gestion financière
+          members_management: Gestion adhérents
+          core: Coeur
+          schedule: Planning
+          diy: Bricolage
+          internal_culture: Culture interne
+          local_suppliers: Fournisseurs locaux
+          other_suppliers: Autres fournisseurs
+          supply: Approvisionnement
+          orders_management: Commande
           it: Informatique
         last_name: Nom
         moderator: Modérateur (forum)


### PR DESCRIPTION
Workgroups have been updated.
The `Member` `group` enum should be extracted later into its own model