### PR TITLE
Admin/add members to missions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ end
 
 group :development do
   gem 'annotate', '~> 2.7', '>= 2.7.4'
-  gem 'erd', '~> 0.6.3'
   gem 'letter_opener'
   gem 'solargraph' # LSP provinding app documention through IDE
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    choice (0.2.0)
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
@@ -151,9 +150,6 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
-    erd (0.6.3)
-      nokogiri
-      rails-erd (>= 0.4.5)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -333,11 +329,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (5.2.3)
@@ -404,7 +395,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-rspec (1.31.0)
       rubocop (>= 0.60.0)
-    ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.14)
       ffi (~> 1.9)
@@ -544,7 +534,6 @@ DEPENDENCIES
   devise (~> 4.7)
   devise_invitable (~> 2.0.0)
   email_spec
-  erd (~> 0.6.3)
   factory_bot_rails (~> 4.0)
   faker
   guard-rspec

--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register Enrollment do
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  permit_params :member_id, :start_time, :end_time
+  belongs_to :mission
+
+  index do
+    column :member
+    column :mission
+    column(:start_time) do |enrollment| enrollment.start_time.strftime('%H:%M') end
+    column(:end_time) do |enrollment| enrollment.end_time.strftime('%H:%M') end
+    actions
+  end
+
+  form do |f|
+    f.inputs :member, :start_time, :end_time
+    actions
+  end
+end

--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -33,5 +33,36 @@ ActiveAdmin.register Mission do
 
     actions
   end
+
+  show do
+    attributes_table do
+      row :name
+      row :description
+      row :start_date
+      row :due_date
+      row :min_member_count
+      row :max_member_count
+      row :delivery_expected
+      row :event
+    end
+
+    panel 'Participants' do
+      table_for resource.enrollments do
+        column :member
+        column(:start_time) do |enrollment| enrollment.start_time.strftime('%H:%M') end
+        column(:end_time) do |enrollment| enrollment.end_time.strftime('%H:%M') end
+        column 'actions' do |enrollment|
+          link_to(t('active_admin.edit'), edit_admin_mission_enrollment_path(mission, enrollment)) +
+            ' ' +
+            link_to(t('active_admin.delete'), admin_mission_enrollment_path(mission, enrollment), method: :delete)
+        end
+      end
+    end
+  end
+
+  action_item :create_enrollment, only: :show do
+    link_to t('active_admin.new_model', model: Enrollment.model_name.human),
+            new_admin_mission_enrollment_path(resource)
+  end
 end
 # rubocop: enable Metrics/BlockLength

--- a/app/policies/enrollment_policy.rb
+++ b/app/policies/enrollment_policy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class EnrollmentPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def index?
+    super_admin?
+  end
+
+  def show?
+    super_admin?
+  end
+
+  def create?
+    super_admin?
+  end
+
+  def update?
+    super_admin?
+  end
+
+  def destroy?
+    super_admin?
+  end
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,6 +24,9 @@ fr:
       address:
         one: Addresse
         other: Addresses
+      enrollment:
+        one: Participant
+        other: Participants
       member:
         one: Membre
         other: Membres
@@ -39,6 +42,10 @@ fr:
         postal_code: code postal
         street_name_1: Numéro et nom de voie
         street_name_2: Complément d'addresse
+      enrollment:
+        member: membre
+        start_time: heure de début
+        end_time: heure de fin
       member:
         avatar: Photo de profil
         biography: Présentation

--- a/spec/policies/enrollment_policy_spec.rb
+++ b/spec/policies/enrollment_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe EnrollmentPolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Allows an admin to edit members enrollments to a mission (previously, only members themselves could to it)

* set Enrollment resource in ActiveAdmin
* set Enrollment Policy to allow super_admins only
* update locales
* uninstall `erd` gem, because of CI issues