### PR TITLE
[Front-end] Show Documents instead of Infos

### DIFF
--- a/app/controllers/infos_controller.rb
+++ b/app/controllers/infos_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-# Newsfeeds, creatable by admins
+# Newsfeeds, creatable by admins.
+#
+# TODO:  <15-04-20, tim> #
+# For the moment, the newsfeed feature is useless and is used only to manage documents.
+# This role should be replaced with a proper DocumentsController and related index view.
 class InfosController < ApplicationController
   before_action :authenticate_member!
 

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,6 +1,7 @@
   <tr>
     <td scope="row">
-      <%= document.file.filename.to_s %>
+      <%= link_to document.file.filename.to_s,
+                  rails_blob_path(document.file, disposition: "attachment") %>
     </td>
     <td scope="row">
       <% if document.file.previewable? %>

--- a/app/views/infos/index.html.erb
+++ b/app/views/infos/index.html.erb
@@ -7,33 +7,15 @@
 
     <div class="page-title">
       <h2 class="heading-infos heading heading-2 text-uppercase border-bottom border-dark strong-800 mt-5 mb-5">
-        Infos
+        Documents
       </h2>
     </div>
 
-    <ul class="nav nav-tabs justify-content-center mb-5" id="infosTabs">
-      <li class="nav-item">
-        <a class="nav-link active" href="#annonces" data-toggle="tab" role="tab">Annonces</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="#documents" data-toggle="tab" role="tab">
-          <%= Document.model_name.plural.capitalize %>
-        </a>
-      </li>
-    </ul>
-
-    <div class="tab-content" id="myTabContent">
-      <div class="tab-pane fade show active" id="annonces" role="tabpanel" aria-labelledby="annonces-tab">
-        <%= render partial: "annonces", locals: {infos: @infos} %>
-      </div>
-
-      <div class="tab-pane fade" id="documents" role="tabpanel" aria-labelledby="documents-tab">
-        <%= render partial: "documents/new",
-                   locals: {document: @document} if policy(Document).create? %>
-        <%= render partial: "documents/index", locals: {documents: @documents} %>
-      </div>
+    <div class="" id="documents">
+      <%= render partial: "documents/new",
+                 locals: {document: @document} if policy(Document).create? %>
+      <%= render partial: "documents/index", locals: {documents: @documents} %>
     </div>
-
   </div>
 </div>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -43,7 +43,7 @@
           </li>
 
           <li class="nav-item dropdown megamenu">
-            <%= link_to Info.model_name.human.pluralize,
+            <%= link_to Document.model_name.human.pluralize,
                         main_app.infos_path,
                         class: "nav-link"  %>
           </li>


### PR DESCRIPTION
Infos are unused, and Users can't find documents, nor upload them. Get
rid of Infos on the front-end in favor of Documents; controllers and
views should be updated accordingly later.