### PR TITLE
Track members working hours, set family concept

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,6 @@ AllCops:
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'
-    - 'config/environments/*.rb'
     - 'bin/*'
 
 # Style/DateTime:
@@ -30,6 +29,7 @@ Metrics/BlockLength:
     - 'Guardfile'
     - 'vendor/bundle'
     - 'app/admin/productors.rb'
+    - 'config/environments/*.rb'
 
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,18 @@ Metrics/BlockLength:
     - 'Guardfile'
     - 'vendor/bundle'
     - 'app/admin/productors.rb'
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ end
 
 group :development do
   gem 'annotate', '~> 2.7', '>= 2.7.4'
+  gem 'bullet', group: 'development'
   gem 'letter_opener'
   gem 'solargraph' # LSP provinding app documention through IDE
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 
+# Rails base gems
 gem 'bootstrap', '~> 4.3.1'
 gem 'image_processing', '~> 1.9', '>= 1.9.3'
 gem 'jbuilder', '~> 2.5'
@@ -15,6 +16,9 @@ gem 'rails', '~> 5.2', '>= 5.2.4'
 gem 'sass-rails', '~> 5.0'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
+
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', '>= 1.1.0', require: false
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
@@ -27,18 +31,14 @@ gem 'uglifier', '>= 1.3.0'
 
 gem 'mini_magick', '~> 4.9.5' # Use ActiveStorage variant
 
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
-
 gem 'active_storage_validations'
 gem 'activeadmin' # Admin interface
 gem 'addressable' # URI manipulations
-gem "aws-sdk-s3", require: false # S3 file upload storage
+gem 'aws-sdk-s3', require: false # S3 file upload storage
 gem 'bootstrap4-datetime-picker-rails'
 gem 'cocoon', '~> 1.2', '>= 1.2.12' # Dynamic nested forms
-gem "devise", "~> 4.7" # Users login/registration management
+gem 'devise', '~> 4.7' # Users login/registration management
 gem 'devise_invitable', '~> 2.0.0'
-gem 'faker' # Generate fake data for the seed.rb and spec factories
 gem 'httparty' # Http requests
 gem 'ice_cube' # Calendar events recurrence (for Missions)
 gem 'leaflet-rails' # GeoMap generator
@@ -49,6 +49,7 @@ gem 'thredded', '~> 0.16.13' # Forum engine
 
 group :development, :test do
   gem 'factory_bot_rails', '~> 4.0'
+  gem 'faker' # Generate fake data for the seed.rb and spec factories
   gem 'guard-rspec', require: false
   gem 'pry-byebug', '~> 3.6'
   gem 'rspec-rails', '~> 3.7', '>= 3.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,9 @@ GEM
       moment-timezone-rails (~> 1.0)
       momentjs-rails (>= 2.10.5, <= 3.0.0)
     builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (10.0.2)
     capybara (3.12.0)
       addressable
@@ -511,6 +514,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.7.0)
+    uniform_notifier (1.13.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -537,6 +541,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
   bootstrap4-datetime-picker-rails
+  bullet
   capybara (>= 2.15)
   chromedriver-helper
   cocoon (~> 1.2, >= 1.2.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,7 +443,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    solargraph (0.38.6)
+    solargraph (0.39.7)
       backport (~> 1.1)
       benchmark
       bundler (>= 1.17.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,7 +297,7 @@ GEM
       sanitize
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.1.1)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     pg (1.1.3)
     popper_js (1.14.5)
@@ -459,7 +459,7 @@ GEM
       rubocop (~> 0.52)
       thor (~> 1.0)
       tilt (~> 2.0)
-      yard (~> 0.9)
+      yard (~> 0.9, >= 0.9.24)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
@@ -527,7 +527,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.24)
+    yard (0.9.25)
 
 PLATFORMS
   ruby

--- a/app/admin/members.rb
+++ b/app/admin/members.rb
@@ -10,6 +10,7 @@ ActiveAdmin.register Member do
     column :first_name
     column :last_name
     column :role
+    column '3 heures faites?' do |member| member.worked_three_hours?(Date.current) end
     column :group do |member| Member.human_enum_name(:group, member.group) end
     column :cash_register_proficiency
     column :email
@@ -31,22 +32,25 @@ ActiveAdmin.register Member do
   filter :cash_register_proficiency
 
   action_item :invite_member, only: :index do
-    link_to t("active_admin.invite_member"), new_member_invitation_path
+    link_to t('active_admin.invite_member'), new_member_invitation_path
   end
 
   controller do
     def create(options = {}, &block)
       new_unloggable_member = build_resource
-      first_name, last_name = new_unloggable_member.first_name, new_unloggable_member.last_name
+      first_name = new_unloggable_member.first_name
+      last_name = new_unloggable_member.last_name
       new_unloggable_member.email = "#{first_name}.#{last_name}.#{Date.current}@compte.web.inactif"
 
-      def new_unloggable_member.password_required?; false; end
-
-      def new_unloggable_member.email_required?; false; end
-
-      if create_resource(new_unloggable_member)
-        options[:location] ||= smart_resource_url
+      def new_unloggable_member.password_required?
+        false
       end
+
+      def new_unloggable_member.email_required?
+        false
+      end
+
+      options[:location] ||= smart_resource_url if create_resource(new_unloggable_member)
 
       respond_with_dual_blocks(new_unloggable_member, options, &block)
     end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -6,21 +6,21 @@ class MembersController < ApplicationController
   before_action :set_authorized_member, only: %i[show edit update]
 
   def index
-    @members = Member.includes(:address, :avatar_attachment)
+    @members = Member.includes(:address, :avatar_attachment).order(last_name: :asc)
   end
 
   def show; end
 
   def edit
-    @member_address = @member.address || @member.build_address
+    @member.build_address if @member.address.blank?
   end
 
   def update
-    if @member.update_attributes(permitted_params)
-      flash[:notice] = t "activerecord.notices.messages.update_success"
+    if @member.update(permitted_params)
+      flash[:notice] = t 'activerecord.notices.messages.update_success'
       render :show
     else
-      flash[:error] = t "activerecord.errors.messages.update_fail"
+      flash[:error] = t 'activerecord.errors.messages.update_fail'
       render :edit
     end
   end
@@ -32,7 +32,9 @@ class MembersController < ApplicationController
       :email, :first_name, :last_name, :group,
       :avatar, :phone_number, :biography,
       :cash_register_proficiency,
-      address_attributes: %i[id postal_code city street_name_1 street_name_2 _destroy],
+      address_attributes: %i[
+        id postal_code city street_name_1 street_name_2 _destroy
+      ]
     )
   end
 

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
+# Helpers for Member-related views
 module MembersHelper
+  def month_total_hours(member, month_number)
+    member
+      .enrollments
+      .select { |enroll| enroll.mission.start_date.month == month_number }
+      .reduce(0.0) { |sum, enrollment| sum + enrollment.duration }
+  end
 end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -2,10 +2,4 @@
 
 # Helpers for Member-related views
 module MembersHelper
-  def month_total_hours(member, month_number)
-    member
-      .enrollments
-      .select { |enroll| enroll.mission.start_date.month == month_number }
-      .reduce(0.0) { |sum, enrollment| sum + enrollment.duration }
-  end
 end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -18,6 +18,12 @@ class Enrollment < ApplicationRecord
 
   before_save :set_defaults
 
+  def duration
+    return 0 if start_time == nil || end_time == nil
+
+    ((end_time - start_time) / 60 / 60).round 1
+  end
+
   private
 
   def set_defaults

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -53,7 +53,7 @@ class Member < ApplicationRecord
 
   has_many :created_infos, class_name: 'Info', inverse_of: 'author', foreign_key: 'author_id', dependent: :nullify
 
-  has_and_belongs_to_many :managed_productors, class_name: "Productor"
+  has_and_belongs_to_many :managed_productors, class_name: 'Productor'
 
   validates :first_name, presence: true
   validates :last_name, presence: true
@@ -82,6 +82,18 @@ class Member < ApplicationRecord
     admin? || super_admin?
   end
 
+  def monthly_worked_hours(date)
+    month_number = date.month
+
+    enrollments
+      .select { |enroll| enroll.mission.start_date.month == month_number }
+      .reduce(0.0) { |sum, enrollment| sum + enrollment.duration }
+  end
+
+  def worked_three_hours?(date)
+    monthly_worked_hours(date) >= 3
+  end
+
   private
 
   def set_unique_display_name
@@ -90,9 +102,7 @@ class Member < ApplicationRecord
     display_name = "#{first_name} #{last_name}"
 
     i = 0
-    while Member.exists?(display_name: display_name)
-      display_name = "#{first_name} #{last_name} #{i += 1}"
-    end
+    display_name = "#{first_name} #{last_name} #{i += 1}" while Member.exists?(display_name: display_name)
 
     self.display_name = display_name
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -85,7 +85,7 @@ class Member < ApplicationRecord
   def monthly_worked_hours(date)
     month_number = date.month
 
-    enrollments
+    family_enrollments
       .select { |enroll| enroll.mission.start_date.month == month_number }
       .reduce(0.0) { |sum, enrollment| sum + enrollment.duration }
   end
@@ -105,5 +105,11 @@ class Member < ApplicationRecord
     display_name = "#{first_name} #{last_name} #{i += 1}" while Member.exists?(display_name: display_name)
 
     self.display_name = display_name
+  end
+
+  def family_enrollments
+    return enrollments if register_id.nil?
+
+    Member.where(register_id: register_id).map(&:enrollments).flatten
   end
 end

--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -15,19 +15,38 @@
 						</div>
 
 						<div class="form-body">
-							<div class="text-center px-2">
-								<h2 class="heading heading-2 strong-400 mb-0">
-									<%= t("main_app.views.members.edit.title").humanize %>
-								</h2>
-							</div>
+              <h2 class='text-center px-2 heading heading-2 strong-400 mb-0'>
+                <%= t '.title_enrollments' %>
+              </h2>
+
+              <table class="table table-sm">
+                <tbody>
+                  <tr>
+                    <th scope="row"><%= l(Date.current, format: '%B').capitalize %></th>
+                    <td><%= month_total_hours(@member, Date.current.month) %> heures</td>
+                  </tr>
+                  <tr>
+                    <th scope="row"><%= l(1.month.ago, format: '%B').capitalize %></th>
+                    <td><%= month_total_hours(@member, 1.months.ago.month) %> heures</td>
+                  </tr>
+                  <tr>
+                    <th scope="row"><%= l(2.month.ago, format: '%B').capitalize %></th>
+                    <td><%= month_total_hours(@member, 2.months.ago.month) %> heures</td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <h2 class="text-center px-2 heading heading-2 strong-400 mb-0">
+                <%= t(".title_edit").humanize %>
+              </h2>
 
 							<div class="form-default mt-4" >
 								<%= render partial: 'form', locals: { member:@member } %>
 							</div>
 
-							<%= link_to t("main_app.views.members.edit.change_password"),
-								edit_member_registration_path,
-								class: "btn-cancel btn btn-styled btn-lg btn-block btn-danger mt-4" %>
+							<%= link_to t(".change_password"),
+                          edit_member_registration_path,
+                          class: "btn-cancel btn btn-styled btn-lg btn-block btn-danger mt-4" %>
 						</div>
 					</div>
 				</div>

--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -19,19 +19,19 @@
                 <%= t '.title_enrollments' %>
               </h2>
 
-              <table class="table table-sm">
+              <table class="table table-sm text-center">
                 <tbody>
                   <tr>
                     <th scope="row"><%= l(Date.current, format: '%B').capitalize %></th>
-                    <td><%= month_total_hours(@member, Date.current.month) %> heures</td>
+                    <td><%= @member.monthly_worked_hours(Date.current) %> heures</td>
                   </tr>
                   <tr>
                     <th scope="row"><%= l(1.month.ago, format: '%B').capitalize %></th>
-                    <td><%= month_total_hours(@member, 1.months.ago.month) %> heures</td>
+                    <td><%= @member.monthly_worked_hours(1.month.ago) %> heures</td>
                   </tr>
                   <tr>
                     <th scope="row"><%= l(2.month.ago, format: '%B').capitalize %></th>
-                    <td><%= month_total_hours(@member, 2.months.ago.month) %> heures</td>
+                    <td><%= @member.monthly_worked_hours(2.months.ago) %> heures</td>
                   </tr>
                 </tbody>
               </table>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
@@ -62,4 +62,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  Bullet.enable = true
+  Bullet.add_footer = true
+  Bullet.bullet_logger = true
 end

--- a/config/locales/main_app.fr.yml
+++ b/config/locales/main_app.fr.yml
@@ -15,9 +15,6 @@ fr:
         messages:
           undefined: Indéfini
       members:
-        edit:
-          title: modifier le profil
-          change_password: Modifier votre mot de passe
         index:
           all_tab: Tous
           member_unconfirmed: Invitation en attente de confirmation

--- a/config/locales/views/members.fr.yml
+++ b/config/locales/views/members.fr.yml
@@ -1,0 +1,10 @@
+fr:
+  members:
+    edit:
+      title_enrollments: Vos participations
+      title_edit: Modifier votre profil
+      change_password: Modifier votre mot de passe
+      hours_count: Nombres d'heures
+      month: Mois
+      this_month: Ce mois-ci
+

--- a/db/migrate/20200510143615_add_register_id_to_members.rb
+++ b/db/migrate/20200510143615_add_register_id_to_members.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Members are registered at the shop's cash register,
+# and can share this Id whith their family
+class AddRegisterIdToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :register_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_191652) do
+ActiveRecord::Schema.define(version: 2020_05_10_143615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,8 @@ ActiveRecord::Schema.define(version: 2020_01_08_191652) do
     t.string "display_name"
     t.boolean "moderator", default: false
     t.integer "cash_register_proficiency", default: 0
+    t.date "end_subscription"
+    t.integer "register_id"
     t.index "lower((display_name)::text) text_pattern_ops", name: "members_display_name_lower", unique: true
     t.index ["confirmation_token"], name: "index_members_on_confirmation_token"
     t.index ["email"], name: "index_members_on_email", unique: true

--- a/spec/factories/missions.rb
+++ b/spec/factories/missions.rb
@@ -25,11 +25,11 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     max_member_count { rand(4..8) }
     min_member_count { rand(1..3) }
-    start_date {
+    start_date do
       Faker::Time.between_dates(from: Date.current.at_beginning_of_week,
                                 to: Date.current.at_end_of_week,
                                 period: :day)
-    }
+    end
     due_date { start_date + 7200 }
     association :author, factory: :member
   end

--- a/spec/features/productors_recap_map_spec.rb
+++ b/spec/features/productors_recap_map_spec.rb
@@ -2,86 +2,85 @@
 
 require 'rails_helper'
 
-RSpec.feature "ProductorsRecapMaps", type: :feature do
-  describe "address coordinates auto-search" do
-    context "when a new productor is created" do
-      let(:productor) { build :productor }
+RSpec.describe 'Productors Recap Maps address coordinates auto-search', type: :feature do
+  context 'when a new productor is created,' do
+    let(:productor) { build :productor }
 
-      context "and an address is given," do
-        it "fetches coordinates if no coordinates are given" do
-          productor.address = build :address
-          allow(productor.address).to receive(:assign_coordinates)
+    context 'when an address is given,' do
+      it 'fetches coordinates if no coordinates are given' do
+        productor.address = build :address
+        allow(productor.address).to receive(:assign_coordinates)
 
-          productor.save
+        productor.save
 
-          expect(productor.address).to have_received(:assign_coordinates)
-        end
+        expect(productor.address).to have_received(:assign_coordinates)
+      end
 
-        it "does not fetch coordinates if coordinates are given" do
-          productor.address = build :address, :coordinates
-          allow(productor.address).to receive(:assign_coordinates)
+      it 'does not fetch coordinates if coordinates are given' do
+        productor.address = build :address, :coordinates
+        allow(productor.address).to receive(:assign_coordinates)
 
-          productor.save
+        productor.save
 
-          expect(productor.address).not_to have_received(:assign_coordinates)
-        end
+        expect(productor.address).not_to have_received(:assign_coordinates)
+      end
+    end
+  end
+
+  context 'when a productor is updated' do
+    let(:productor) { create :productor, address: build(:address, :coordinates) }
+
+    before { allow(productor.address).to receive(:assign_coordinates) }
+
+    context 'when its address is also updated,' do
+      it 'fetches coordinates if no new coordinates are given' do
+        new_address = attributes_for :address
+        productor.update(address_attributes: new_address)
+        expect(productor.address).to have_received(:assign_coordinates)
+      end
+
+      it 'fetches coordinates if empty coordinates are given' do
+        new_address = attributes_for :address, coordinates: ['', '']
+        productor.update(address_attributes: new_address)
+        expect(productor.address).to have_received(:assign_coordinates)
+      end
+
+      it 'does not fetch new coordinates if new coordinates are given' do
+        new_address = attributes_for :address, :coordinates
+        productor.update(address_attributes: new_address)
+        expect(productor.address).not_to have_received(:assign_coordinates)
       end
     end
 
-    context "when a productor is updated" do
-      let(:productor) { create :productor, address: build(:address, :coordinates) }
-      before { allow(productor.address).to receive(:assign_coordinates) }
-
-      context "and its address is also updated," do
-        it "fetches coordinates if no new coordinates are given" do
-          new_address = attributes_for :address
-          productor.update(address_attributes: new_address)
-          expect(productor.address).to have_received(:assign_coordinates)
-        end
-
-        it "fetches coordinates if empty coordinates are given" do
-          new_address = attributes_for :address, coordinates: ['', '']
-          productor.update(address_attributes: new_address)
-          expect(productor.address).to have_received(:assign_coordinates)
-        end
-
-        it "does not fetch new coordinates if new coordinates are given" do
-          new_address = attributes_for :address, :coordinates
-          productor.update(address_attributes: new_address)
-          expect(productor.address).not_to have_received(:assign_coordinates)
-        end
-      end
-
-      context "and its address is not updated," do
-        it "does not fetch coordinates" do
-          productor.update(name: 'test')
-          expect(productor.address).not_to have_received(:assign_coordinates)
-        end
+    context 'when its address is not updated,' do
+      it 'does not fetch coordinates' do
+        productor.update(name: 'test')
+        expect(productor.address).not_to have_received(:assign_coordinates)
       end
     end
+  end
 
-    context "when an address that doesn't belong to a productor is saved," do
-      let(:address) { build :address, coordinates: nil }
+  context "when an address that doesn't belong to a productor is saved," do
+    let(:address) { build :address, coordinates: nil }
 
-      it "doesn't launch Address#assign_coordinates for a Member" do
-        member = build :member
-        member.address = address
-        allow(member.address).to receive(:assign_coordinates)
+    it "doesn't launch Address#assign_coordinates for a Member" do
+      member = build :member
+      member.address = address
+      allow(member.address).to receive(:assign_coordinates)
 
-        member.save
+      member.save
 
-        expect(member.address).not_to have_received(:assign_coordinates)
-      end
+      expect(member.address).not_to have_received(:assign_coordinates)
+    end
 
-      it "doesn't launch Address#assign_coordinates for a Mission" do
-        mission = build :mission
-        mission.addresses << address
-        allow(mission.addresses[0]).to receive(:assign_coordinates)
+    it "doesn't launch Address#assign_coordinates for a Mission" do
+      mission = build :mission
+      mission.addresses << address
+      allow(mission.addresses[0]).to receive(:assign_coordinates)
 
-        mission.save
+      mission.save
 
-        expect(mission.addresses[0]).not_to have_received(:assign_coordinates)
-      end
+      expect(mission.addresses[0]).not_to have_received(:assign_coordinates)
     end
   end
 end

--- a/spec/features/track_members_worked_hours_spec.rb
+++ b/spec/features/track_members_worked_hours_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Members worked hours tracking', type: :feature do
-  context 'when a member goes on his/her profile page,' do
-    let(:member) { create :member }
+  let(:member) { create :member }
 
+  context 'when a member goes on his/her profile page,' do
     before { sign_in member }
 
     it 'shows the number of worked hours this month' do
@@ -42,13 +42,20 @@ RSpec.describe 'Members worked hours tracking', type: :feature do
   end
 
   context 'when a member has enrolled for a task and done it at the shop,' do
-    it 'increases his/her worked hours count on his/her profile'
-    it 'increases his/her worked hours count on the admin interface'
-    it "increases his/her family members' worked hours count on the admin interface"
+    it "increases his/her family members' worked hours count"
   end
 
   context 'when a member has worked >= 3 hours this current month' do
-    it 'shows a :ok status on the admin members index'
+    before { sign_in create :member, :admin }
+
+    it 'shows a :ok status on the admin members index' do
+      create :enrollment, member: member,
+                          mission: create(:mission, start_date: 1.week.ago, due_date: 1.week.ago + 3.hours)
+
+      visit admin_members_path
+
+      expect(page).to have_content I18n.t 'active_admin.status_tag.yes'
+    end
 
     context 'with <= 3 hours worked the previous month' do
       it 'does not show that member on the admin dashboard'
@@ -56,12 +63,18 @@ RSpec.describe 'Members worked hours tracking', type: :feature do
   end
 
   context 'when a member has worked less than 3 hours this current month,' do
-    it 'shows his/her month status as :incomplete on the members admin index'
+    before { sign_in create :member, :admin }
+
+    it 'shows his/her month status as :incomplete on the members admin index' do
+      create :enrollment, member: member
+
+      visit admin_members_path
+
+      expect(page).to have_content I18n.t 'active_admin.status_tag.no'
+    end
   end
 
   context 'when a new month starts,' do
-    it "shows a members' current worked hours as 0"
-
     context 'when a member has not worked 3 hours last month' do
       it 'shows that member on the admin dashboard'
     end

--- a/spec/features/track_members_worked_hours_spec.rb
+++ b/spec/features/track_members_worked_hours_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Members worked hours tracking', type: :feature do
+  context 'when a member goes on his/her profile page,' do
+    let(:member) { create :member }
+
+    before { sign_in member }
+
+    it 'shows the number of worked hours this month' do
+      enrollment = create :enrollment, member: member
+
+      visit edit_member_path member
+
+      expect(page).to have_content enrollment.duration
+    end
+
+    it 'shows the number of worked hours during last month' do
+      last_month_enrollment = create :enrollment,
+                                     member: member,
+                                     mission: create(:mission, start_date: 1.month.ago)
+
+      visit edit_member_path member
+
+      expect(page).to have_content last_month_enrollment.duration
+    end
+
+    it 'shows the number of worked hours during last last month' do
+      last_last_month_enrollment = create :enrollment,
+                                          member: member,
+                                          mission: create(:mission, start_date: 2.months.ago)
+
+      visit edit_member_path member
+
+      expect(page).to have_content last_last_month_enrollment.duration
+    end
+
+    it 'does not raise errors if he/she has no enrollment' do
+      expect { visit edit_member_path member }.not_to raise_error
+    end
+  end
+
+  context 'when a member has enrolled for a task and done it at the shop,' do
+    it 'increases his/her worked hours count on his/her profile'
+    it 'increases his/her worked hours count on the admin interface'
+    it "increases his/her family members' worked hours count on the admin interface"
+  end
+
+  context 'when a member has worked >= 3 hours this current month' do
+    it 'shows a :ok status on the admin members index'
+
+    context 'with <= 3 hours worked the previous month' do
+      it 'does not show that member on the admin dashboard'
+    end
+  end
+
+  context 'when a member has worked less than 3 hours this current month,' do
+    it 'shows his/her month status as :incomplete on the members admin index'
+  end
+
+  context 'when a new month starts,' do
+    it "shows a members' current worked hours as 0"
+
+    context 'when a member has not worked 3 hours last month' do
+      it 'shows that member on the admin dashboard'
+    end
+  end
+end

--- a/spec/features/track_members_worked_hours_spec.rb
+++ b/spec/features/track_members_worked_hours_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe 'Members worked hours tracking', type: :feature do
     end
   end
 
-  context 'when a member has enrolled for a task and done it at the shop,' do
-    it "increases his/her family members' worked hours count"
-  end
-
   context 'when a member has worked >= 3 hours this current month' do
     before { sign_in create :member, :admin }
 

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -14,14 +14,36 @@
 require 'rails_helper'
 
 RSpec.describe Enrollment, type: :model do
-  describe "instanciation" do
+  describe 'instanciation' do
     let(:enrollment) { create :enrollment }
 
-    it "set :start_time default value to the associated mission start" do
+    it 'set :start_time default value to the associated mission start' do
       expect(enrollment.start_time.strftime('%T')).to eq enrollment.mission.start_date.strftime('%T')
     end
-    it "set :end_time default value to the associated mission end" do
+    it 'set :end_time default value to the associated mission end' do
       expect(enrollment.end_time.strftime('%T')).to eq enrollment.mission.due_date.strftime('%T')
+    end
+  end
+
+  describe '#duration' do
+    it 'gives the duration of an enrollment in hours' do
+      enrollment = build :enrollment, start_time: Time.current, end_time: Time.current + 2.hours
+
+      expect(enrollment.duration).to eq 2
+    end
+
+    it 'gives a rounded duration in hours' do
+      enrollment = build :enrollment, start_time: Time.current, end_time: Time.current + 1.5.hours
+
+      expect(enrollment.duration).to eq 1.5
+    end
+
+    it 'returns 0 if any start_time attribute is undefined' do
+      expect(Enrollment.new(end_time: Time.current).duration).to eq 0
+    end
+
+    it 'returns 0 if any end_time attribute is undefined' do
+      expect(Enrollment.new(start_time: Time.current).duration).to eq 0
     end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -39,7 +39,7 @@ require 'rails_helper'
 
 RSpec.describe Member, type: :model do
   describe 'Model instanciation' do
-    subject { described_class.new }
+    subject(:instance) { described_class.new }
 
     describe 'Database' do
       it { is_expected.to have_db_column(:id).of_type(:integer) }
@@ -66,28 +66,32 @@ RSpec.describe Member, type: :model do
     describe 'associations' do
       it { is_expected.to accept_nested_attributes_for(:address).allow_destroy(true) }
       it { is_expected.to have_one(:address).dependent(:destroy) }
-      it { is_expected.to have_many(:created_missions).class_name('Mission').with_foreign_key('author_id').dependent(:nullify) }
+      it {
+        expect(instance).to have_many(:created_missions)
+          .class_name('Mission').with_foreign_key('author_id')
+          .dependent(:nullify)
+      }
       it { is_expected.to have_many(:missions).through(:enrollments) }
     end
 
-    describe "validations" do
+    describe 'validations' do
       it { is_expected.to validate_presence_of(:first_name) }
       it { is_expected.to validate_presence_of(:last_name) }
       it { is_expected.to validate_presence_of(:display_name) }
     end
   end
 
-  describe "#set_unique_display_name" do
+  describe '#set_unique_display_name' do
     let(:member) { create :member }
 
-    it "sets the display_name attribute on creation" do
+    it 'sets the display_name attribute on creation' do
       new_member = build :member
       new_member.save
       expect(new_member.reload.display_name).to eq "#{new_member.first_name} #{new_member.last_name}"
     end
 
-    context "when a pre-existing member without :display_name is updated" do
-      it "sets a display_name" do
+    context 'when a pre-existing member without :display_name is updated' do
+      it 'sets a display_name' do
         old_member = build :member
         old_member.save(validate: false)
 
@@ -97,14 +101,14 @@ RSpec.describe Member, type: :model do
       end
     end
 
-    context "when a member is created with already existing first_name and last_name," do
-      it "checks uniqueness of :display_name by appending it a number" do
+    context 'when a member is created with already existing first_name and last_name,' do
+      it 'checks uniqueness of :display_name by appending it a number' do
         new_member = create :member, first_name: member.first_name,
                                      last_name: member.last_name
         expect(new_member.display_name).to eq "#{new_member.first_name} #{new_member.last_name} 1"
       end
 
-      it "checks uniqueness of :display_name by appending it an incrementing number" do
+      it 'checks uniqueness of :display_name by appending it an incrementing number' do
         create :member, first_name: member.first_name,
                         last_name: member.last_name
         new_member = create :member, first_name: member.first_name,
@@ -113,8 +117,8 @@ RSpec.describe Member, type: :model do
       end
     end
 
-    context "when a member updates, without changing his/her name" do
-      it "does not change :display_name" do
+    context 'when a member updates, without changing his/her name' do
+      it 'does not change :display_name' do
         member = create :member
         display_name = member.display_name
         member.update(phone_number: 'whatever')
@@ -122,18 +126,21 @@ RSpec.describe Member, type: :model do
       end
     end
 
-    context "when a member updates, and the name is edited," do
+    context 'when a member updates, and the name is edited,' do
       let(:first_name) { 'new' }
       let(:last_name) { 'name' }
 
-      before { member.first_name, member.last_name = first_name, last_name }
+      before do
+        member.first_name = first_name
+        member.last_name = last_name
+      end
 
-      it "update :display_name accordingly" do
+      it 'update :display_name accordingly' do
         member.save
         expect(member.reload.display_name).to eq "#{first_name} #{last_name}"
       end
 
-      it "appends an number to :display_name if it already exists" do
+      it 'appends an number to :display_name if it already exists' do
         create :member, first_name: first_name, last_name: last_name
         member.save
         expect(member.reload.display_name).to eq "#{first_name} #{last_name} 1"
@@ -141,23 +148,35 @@ RSpec.describe Member, type: :model do
     end
   end
 
-  describe "#thredded_admin? (forum admin rights)" do
-    context "when member is super admin," do
+  describe '#thredded_admin? (forum admin rights)' do
+    context 'when member is super admin,' do
       subject { build_stubbed :member, :super_admin }
 
       it { is_expected.to be_thredded_admin }
     end
 
-    context "when member is an admin," do
+    context 'when member is an admin,' do
       subject { build_stubbed :member, :admin }
 
       it { is_expected.to be_thredded_admin }
     end
 
-    context "when member is not an admin" do
+    context 'when member is not an admin' do
       subject { build_stubbed :member }
 
       it { is_expected.not_to be_thredded_admin }
+    end
+  end
+
+  describe '#monthly_worked_hours' do
+    context 'when a member shares the same register_id with his/her family' do
+      let(:member) { create :member, register_id: 1234 }
+      let(:family_member) { create :member, register_id: 1234 }
+
+      it "affects every family members' worked hours count" do
+        create :enrollment, member: family_member
+        expect(member.monthly_worked_hours(Date.current)).to eq family_member.monthly_worked_hours(Date.current)
+      end
     end
   end
 end


### PR DESCRIPTION
References #171 

Families are members that share the same `register_id`. When a member of a family works at the
shop, the other members of that family see their monthly_count increased

* Add `register_id` attribute to `Member` model
* Add monthly worked hours count on member profile
* Add monthly 3h worked hours 'done' status on `admin/members`