### PR TITLE
Recurrent change option for mission

### DIFF
--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -88,7 +88,7 @@ ActiveAdmin.register Mission do
       end
     end
 
-    # helpers
+    private
 
     def generate_update_transaction
       Admin::Missions::UpdateTransaction

--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -11,7 +11,8 @@ ActiveAdmin.register Mission do
                 :min_member_count,
                 :start_date,
                 :due_date,
-                :cash_register_proficiency_requirement
+                :cash_register_proficiency_requirement,
+                :recurrent_change
 
   index do
     selectable_column
@@ -40,6 +41,7 @@ ActiveAdmin.register Mission do
       f.input :cash_register_proficiency_requirement,
               :as => :select,
               collection => Mission.cash_register_proficiency_requirements
+      f.input :recurrent_change, as: :boolean if f.object.persisted?
     end
 
     actions
@@ -63,8 +65,8 @@ ActiveAdmin.register Mission do
     panel 'Participants' do
       table_for resource.enrollments do
         column :member
-        column(:start_time) do |enrollment| enrollment.start_time.strftime('%H:%M') end
-        column(:end_time) do |enrollment| enrollment.end_time.strftime('%H:%M') end
+        column(:start_time) { |enrollment| enrollment.start_time.strftime('%H:%M') }
+        column(:end_time) { |enrollment| enrollment.end_time.strftime('%H:%M') }
         column 'actions' do |enrollment|
           link_to(t('active_admin.edit'), edit_admin_mission_enrollment_path(mission, enrollment)) +
             ' ' +

--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -76,6 +76,28 @@ ActiveAdmin.register Mission do
     end
   end
 
+  controller do
+    def update
+      if update_transaction.success?
+        redirect_to admin_mission_path(resource.id)
+      else
+        render :edit
+      end
+    end
+
+    # helpers
+
+    def update_transaction
+      Admin::Missions::UpdateTransaction
+        .new
+        .with_step_args(
+          update_mission: [mission: resource],
+          get_updatable_missions: [old_mission: resource]
+        )
+        .call({ params: permitted_params[:mission] })
+    end
+  end
+
   action_item :create_enrollment, only: :show do
     link_to t('active_admin.new_model', model: Enrollment.model_name.human),
             new_admin_mission_enrollment_path(resource)

--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -78,7 +78,6 @@ ActiveAdmin.register Mission do
 
   controller do
     def update
-      update_transaction = generate_update_transaction
       if update_transaction.success?
         flash[:notice] = translate 'activerecord.notices.messages.update_success'
         redirect_to admin_mission_path(resource.id)
@@ -90,14 +89,17 @@ ActiveAdmin.register Mission do
 
     private
 
-    def generate_update_transaction
-      Admin::Missions::UpdateTransaction
-        .new
-        .with_step_args(
-          update_mission: [mission: resource],
-          get_updatable_missions: [old_mission: resource]
-        )
-        .call({ params: permitted_params[:mission] })
+    def update_transaction
+      @update_transaction ||=
+        begin
+          Admin::Missions::UpdateTransaction
+            .new
+            .with_step_args(
+              update_mission: [mission: resource],
+              get_updatable_missions: [old_mission: resource]
+            )
+            .call({ params: permitted_params[:mission] })
+        end
     end
   end
 

--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -78,16 +78,19 @@ ActiveAdmin.register Mission do
 
   controller do
     def update
+      update_transaction = generate_update_transaction
       if update_transaction.success?
+        flash[:notice] = translate 'activerecord.notices.messages.update_success'
         redirect_to admin_mission_path(resource.id)
       else
+        flash[:error] = update_transaction.failure
         render :edit
       end
     end
 
     # helpers
 
-    def update_transaction
+    def generate_update_transaction
       Admin::Missions::UpdateTransaction
         .new
         .with_step_args(

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -27,7 +27,6 @@ class MissionsController < ApplicationController
   def edit; end
 
   def update
-    update_transaction = generate_update_transaction
     if update_transaction.success?
       flash[:notice] = translate 'activerecord.notices.messages.update_success'
       render :show
@@ -72,11 +71,14 @@ class MissionsController < ApplicationController
     end
   end
 
-  def generate_update_transaction
-    Missions::UpdateTransaction.new.with_step_args(
-      transform_time_slots_in_time_params_for_enrollment: [regulated: @mission.regulated?],
-      update: [mission: @mission]
-    ).call(permitted_params)
+  def update_transaction
+    @update_transaction ||=
+      begin
+        Missions::UpdateTransaction.new.with_step_args(
+          transform_time_slots_in_time_params_for_enrollment: [regulated: @mission.regulated?],
+          update: [mission: @mission]
+        ).call(permitted_params)
+      end
   end
 
   def permitted_params

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -27,6 +27,7 @@ class MissionsController < ApplicationController
   def edit; end
 
   def update
+    update_transaction = generate_update_transaction
     if update_transaction.success?
       flash[:notice] = translate 'activerecord.notices.messages.update_success'
       render :show
@@ -71,7 +72,7 @@ class MissionsController < ApplicationController
     end
   end
 
-  def update_transaction
+  def generate_update_transaction
     Missions::UpdateTransaction.new.with_step_args(
       transform_time_slots_in_time_params_for_enrollment: [regulated: @mission.regulated?],
       update: [mission: @mission]

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -55,6 +55,7 @@ class Mission < ApplicationRecord
   # Virtual attributes
   attr_accessor :recurrence_rule
   attr_accessor :recurrence_end_date
+  attr_accessor :recurrent_change
 
   def duration
     (due_date - start_date).round

--- a/app/transactions/admin/missions/update_transaction.rb
+++ b/app/transactions/admin/missions/update_transaction.rb
@@ -8,6 +8,7 @@ module Admin
 
       around :rollback_if_failure
 
+      tee :remove_datetime_attributes_if_recurrent_option
       step :update_mission
       tee :get_updatable_missions
       step :update_recurrently_other_missions
@@ -24,6 +25,15 @@ module Admin
           result
         end
         result
+      end
+
+      def remove_datetime_attributes_if_recurrent_option(input)
+        return Success(input) unless input[:params][:recurrent_change]
+
+        input[:params].delete(:start_date)
+        input[:params].delete(:due_date)
+
+        Success(input)
       end
 
       def update_mission(input, mission:)

--- a/app/transactions/admin/missions/update_transaction.rb
+++ b/app/transactions/admin/missions/update_transaction.rb
@@ -66,10 +66,11 @@ module Admin
       # helpers
 
       def updatable_missions(old_mission)
-        Mission.all.select do |mission|
-          mission.start_date > old_mission.start_date &&
-            mission.start_date.strftime('%R%u') == old_mission.start_date.strftime('%R%u') &&
-            mission.genre == old_mission.genre
+        missions = Mission.where('start_date > :old_mission_start_date AND genre = :old_mission_genre',
+                                 old_mission_start_date: old_mission.start_date,
+                                 old_mission_genre: Mission.genres[old_mission.genre])
+        missions.select do |mission|
+          mission.start_date.strftime('%R%u') == old_mission.start_date.strftime('%R%u')
         end
       end
     end

--- a/app/transactions/admin/missions/update_transaction.rb
+++ b/app/transactions/admin/missions/update_transaction.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Admin
+  module Missions
+    # update mission and update recurrently if the recurrent change params is given
+    class UpdateTransaction
+      include Dry::Transaction
+
+      step :update_mission
+      tee :get_updatable_missions
+      step :update_recurrently_other_missions
+
+      private
+
+      def update_mission(input, mission:)
+        if mission.update(input[:params])
+          Success(input)
+        else
+          Failure(failure_message)
+        end
+      end
+
+      def get_updatable_missions(input, old_mission:)
+        return Success(input) unless input[:params][:recurrent_change]
+
+        input.merge!({ missions: updatable_missions(old_mission) })
+        Success(input)
+      end
+
+      def update_recurrently_other_missions(input)
+        return Success(input) unless input[:params][:recurrent_change]
+
+        input[:missions].each do |mission|
+          return Failure(failure_message) unless mission.update(input[:params])
+        end
+        Success(input)
+      end
+
+      # helpers
+
+      def updatable_missions(old_mission)
+        Mission.all.select do |mission|
+          mission.start_date > old_mission.start_date &&
+            mission.start_date.strftime('%R%u') == old_mission.start_date.strftime('%R%u') &&
+            mission.genre == old_mission.genre
+        end
+      end
+    end
+  end
+end

--- a/app/transactions/admin/missions/update_transaction.rb
+++ b/app/transactions/admin/missions/update_transaction.rb
@@ -6,7 +6,7 @@ module Admin
     class UpdateTransaction
       include Dry::Transaction
 
-      around :transaction
+      around :rollback_if_failure
 
       step :update_mission
       tee :get_updatable_missions
@@ -14,7 +14,7 @@ module Admin
 
       private
 
-      def transaction(input, &block)
+      def rollback_if_failure(input, &block)
         result = nil
 
         Mission.transaction do

--- a/config/locales/models/mission.en.yml
+++ b/config/locales/models/mission.en.yml
@@ -12,6 +12,7 @@ en:
           event: Event
           regulated: Regulated
           standard: Standard
+        recurrent_change: Recurrent change
     errors:
       models:
         mission:

--- a/config/locales/models/mission.fr.yml
+++ b/config/locales/models/mission.fr.yml
@@ -12,6 +12,7 @@ fr:
           event: Événement
           regulated: Régulée
           standard: Standard
+        recurrent_change: Changement Récurrent
     errors:
       models:
         mission:

--- a/spec/requests/admin/missions_spec.rb
+++ b/spec/requests/admin/missions_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'A Missions admin request', type: :request do
       end
 
       it 'updates futures missions that match the same week day, hour, and genre' do # rubocop:disable Layout/LineLength
-        other_missions = create_future_matching_mission(updated_mission)
+        other_missions = create_future_matching_missions(updated_mission)
 
         put_mission
 
@@ -74,7 +74,7 @@ RSpec.describe 'A Missions admin request', type: :request do
     end
   end
 
-  def create_future_matching_mission(mission)
+  def create_future_matching_missions(mission)
     occurrence_date = mission.start_date + 7.days
     other_missions = []
     4.times do

--- a/spec/requests/admin/missions_spec.rb
+++ b/spec/requests/admin/missions_spec.rb
@@ -30,9 +30,14 @@ RSpec.describe 'A Missions admin request', type: :request do
 
     context 'when the recurrent changes params is true' do
       let(:updated_mission) { create :mission, start_date: DateTime.current + 2.days }
-      let(:mission_params) { { name: 'updated_mission', recurrent_change: true } }
+      let(:mission_params) do
+        { name: 'updated_mission',
+          recurrent_change: true,
+          start_date: updated_mission.start_date + 3.hours,
+          due_date: updated_mission.due_date + 3.hours }
+      end
 
-      it 'changes the missions with the same week day, the same hour, same genre and who are planned after the updated mission' do # rubocop:disable Layout/LineLength
+      it 'updates futures missions that match the same week day, hour, and genre' do # rubocop:disable Layout/LineLength
         other_missions = create_same_missions_planned_after_this_mission(updated_mission)
 
         put_mission
@@ -42,15 +47,25 @@ RSpec.describe 'A Missions admin request', type: :request do
         end
       end
 
-      it "doesn't change the missions with the same week day, the same hour, same genre and who are planned before the updated mission" do # rubocop:disable Layout/LineLength
+      it "doesn't update pasts missions that match the same week day, hour, and genre" do # rubocop:disable Layout/LineLength
         other_mission = create :mission, start_date: updated_mission.start_date - 2.days
 
         put_mission
 
         expect(other_mission.reload.name).not_to eq 'updated_mission'
       end
+
+      it "doesn't update :start_date attribute" do
+        expect { put_mission }.not_to change(updated_mission, :start_date)
+      end
+
+      it "doesn't update :due_date attribute" do
+        expect { put_mission }.not_to change(updated_mission, :due_date)
+      end
     end
   end
+
+  # helpers
 
   def create_history_of_generated_schedule_for_n_months(months_count)
     (1..months_count).each do |n|

--- a/spec/requests/admin/missions_spec.rb
+++ b/spec/requests/admin/missions_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'A Missions admin request', type: :request do
       end
 
       it 'updates futures missions that match the same week day, hour, and genre' do # rubocop:disable Layout/LineLength
-        other_missions = create_same_missions_planned_after_this_mission(updated_mission)
+        other_missions = create_future_matching_mission(updated_mission)
 
         put_mission
 
@@ -74,12 +74,12 @@ RSpec.describe 'A Missions admin request', type: :request do
     end
   end
 
-  def create_same_missions_planned_after_this_mission(mission)
-    occurrente_date = mission.start_date + 7.days
+  def create_future_matching_mission(mission)
+    occurrence_date = mission.start_date + 7.days
     other_missions = []
     4.times do
-      other_missions << create(:mission, start_date: occurrente_date, genre: mission.genre)
-      occurrente_date += 7.days
+      other_missions << create(:mission, start_date: occurrence_date, genre: mission.genre)
+      occurrence_date += 7.days
     end
     other_missions
   end

--- a/spec/requests/missions_spec.rb
+++ b/spec/requests/missions_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'A Mission request', type: :request do
     subject(:put_mission) { put mission_path(mission.id), params: { mission: mission_params } }
 
     let(:mission) { create :mission }
-    let(:mission_params) {  { name: 'updated_mission' } }
+    let(:mission_params) { { name: 'updated_mission' } }
 
     before { sign_in create :member, :super_admin }
 


### PR DESCRIPTION
Add a recurrent change option for missions.

If this option is enable, the admin update will change all mission with the same hours, same week day and the same type planned after the updated mission.

https://github.com/Mate2xo/Creeons_la_coop/issues/248