### PR TITLE
Quick fixes of static planning

### DIFF
--- a/app/services/static_members_recruiter.rb
+++ b/app/services/static_members_recruiter.rb
@@ -42,19 +42,18 @@ class StaticMembersRecruiter
 
   def merge_multi_enrolls_on_one_mission(member)
     member.missions.each do |mission|
-      merge_enrolls(mission.enrollments) if mission.enrollments.count > 1
+      enrollments = Enrollment.where(member_id: member.id, mission_id: mission.id)
+      merge_enrolls(enrollments) if enrollments.count > 1
     end
   end
 
   def merge_enrolls(enrollments)
-    return if enrollments.count < 2
-
     enrollments = enrollments.order(:start_time)
-    Enrollment.create(start_time: enrollments.first.start_time,
-                      end_time: enrollments.last.end_time,
-                      mission_id: enrollments.first.mission_id,
-                      member_id: enrollments.first.member_id)
-    enrollments.destroy_all
+    enrollment_is_create = Enrollment.create(start_time: enrollments.first.start_time,
+                                             end_time: enrollments.last.end_time,
+                                             mission_id: enrollments.first.mission_id,
+                                             member_id: enrollments.first.member_id)
+    enrollments.destroy_all if enrollment_is_create
   end
 
   def enrollments_for_one_static_slot(member, static_slot)

--- a/app/services/static_members_recruiter.rb
+++ b/app/services/static_members_recruiter.rb
@@ -49,11 +49,11 @@ class StaticMembersRecruiter
 
   def merge_enrolls(enrollments)
     enrollments = enrollments.order(:start_time)
-    enrollment_is_create = Enrollment.create(start_time: enrollments.first.start_time,
-                                             end_time: enrollments.last.end_time,
-                                             mission_id: enrollments.first.mission_id,
-                                             member_id: enrollments.first.member_id)
-    enrollments.destroy_all if enrollment_is_create
+    enrollment_created = Enrollment.create(start_time: enrollments.first.start_time,
+                                           end_time: enrollments.last.end_time,
+                                           mission_id: enrollments.first.mission_id,
+                                           member_id: enrollments.first.member_id)
+    enrollments.destroy_all if enrollment_created
   end
 
   def enrollments_for_one_static_slot(member, static_slot)

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -58,7 +58,7 @@
           class:'form-control' %>
       </div>
 
-      <% if @member.static_slots.empty? %>
+      <% if @member.static_slots.empty? && @member == current_member %>
         <div class="links">
           <%= link_to_add_association form,
             :static_slots,

--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -47,7 +47,7 @@
 							<%= link_to t(".change_password"),
                           edit_member_registration_path,
                           class: "btn-cancel btn btn-styled btn-lg btn-block btn-danger mt-4" %>
-              <% if member_signed_in? && current_member.static_slots.any? %>
+              <% if current_member == @member && current_member.static_slots.any? %>
                 <%= button_to t('.reset_static_slots'),
                   member_static_slot_path(1),
                   method: :delete,


### PR DESCRIPTION
fix `private#merge_enrolls` in recruiter in order to merge only the enrolls with same `:member_id` `:and mission_id`.

Fix static slots buttons in order to appear only in profile of current member.