### PR TITLE
rm_useless_fonction

### DIFF
--- a/db/restore_enrollments/enrollments_restoration_from_csv_file.sql
+++ b/db/restore_enrollments/enrollments_restoration_from_csv_file.sql
@@ -69,21 +69,10 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE PROCEDURE copy_csv_in_db()
-LANGUAGE plpgsql AS $$
-BEGIN
-  COPY temp_enrollments_from_csv (member_id, mission_id, id, start_time, end_time)
-  FROM '/app/db/restore_enrollments/enrollments_from_2020_10_01_to_2021_01_04.csv' DELIMITER ',' CSV HEADER;
-END;
-$$;
-
 
 START TRANSACTION;
 
-CREATE TEMPORARY TABLE temp_enrollments_from_csv AS
-SELECT * FROM enrollments LIMIT 0;
-
-call copy_csv_in_db();
 call restore_enrollments_for_missions_in_last_three_months();
+
 COMMIT;
 


### PR DESCRIPTION
This branch remove useless copy function from `restore_enrollments_from_csv.sql` file. 
This function is ensured by psql console.