### PR TITLE
Fix bug on event in admin views

### DIFF
--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -22,7 +22,9 @@ ActiveAdmin.register Mission do
     column(:genre) { |mission| Mission.human_enum_name(:genre, mission.genre) }
     column :due_date
     column :author
-    column :cash_register_proficiency_requirement
+    column :cash_register_proficiency_requirement do |mission|
+      Mission.human_enum_name('cash_register_proficiency_requirement', mission.cash_register_proficiency_requirement)
+    end
     actions
   end
 

--- a/app/admin/missions.rb
+++ b/app/admin/missions.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Mission do
   permit_params :author_id,
                 :name,
                 :description,
-                :event,
+                :genre,
                 :delivery_expected,
                 :max_member_count,
                 :min_member_count,
@@ -19,7 +19,7 @@ ActiveAdmin.register Mission do
     column :name
     column :description
     column :delivery_expected
-    column :event
+    column(:genre) { |mission| Mission.human_enum_name(:genre, mission.genre) }
     column :due_date
     column :author
     column :cash_register_proficiency_requirement
@@ -33,7 +33,7 @@ ActiveAdmin.register Mission do
       f.input :name
       f.input :description
       f.input :delivery_expected
-      f.input :event
+      f.input :genre
       f.input :max_member_count
       f.input :min_member_count
       f.input :start_date
@@ -56,7 +56,7 @@ ActiveAdmin.register Mission do
       row :min_member_count
       row :max_member_count
       row :delivery_expected
-      row :event
+      row(:genre) { |mission| Mission.human_enum_name(:genre, mission.genre) }
       row(:cash_register_proficiency_requirement) do |resource|
         Mission.human_enum_name('cash_register_proficiency_requirement', resource.cash_register_proficiency_requirement)
       end

--- a/db/convert_event_bool_in_genre_enum/convert_event_bool_in_genre_enum.sql
+++ b/db/convert_event_bool_in_genre_enum/convert_event_bool_in_genre_enum.sql
@@ -1,0 +1,7 @@
+START TRANSACTION;
+
+UPDATE Missions
+  SET genre = 2
+  WHERE event is true;
+
+COMMIT;

--- a/db/convert_event_bool_in_genre_enum/convert_event_bool_in_genre_enum.sql
+++ b/db/convert_event_bool_in_genre_enum/convert_event_bool_in_genre_enum.sql
@@ -1,7 +1,7 @@
 START TRANSACTION;
 
 UPDATE Missions
-  SET genre = 2
+  SET genre = 2 -- 2 is key for the genre 'event'
   WHERE event is true;
 
 COMMIT;

--- a/lib/tasks/convert_event_bool_in_enum_genre.rake
+++ b/lib/tasks/convert_event_bool_in_enum_genre.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This namespace contain all tasks who adapt the data at changements of db structure
+namespace :convertion do # rubocop:disable Metrics/BlockLength
+  desc 'it set enum genre at event for mission who have the event boolean at true'
+  task convert_event_bool_in_enum_genre: :environment do
+    puts ''.ljust 80, '*'
+    puts 'start migration'.center 80
+    puts ''.ljust 80, '*'
+    file = File.open(Rails.root.join('db/convert_event_bool_in_genre_enum/convert_event_bool_in_genre_enum.sql'))
+    ActiveRecord::Base.connection.execute(file.read)
+    file.close
+    puts ''.ljust 80, '*'
+    puts 'migration done'.center 80
+    puts ''.ljust 80, '*'
+
+    puts ''.ljust 80, '*'
+    if check_data_consistency_for_event_bool_convertion
+      puts 'migration success'.center 80
+    else
+      puts 'migration failure'.center 80
+    end
+    puts ''.ljust 80, '*'
+  end
+end
+
+def check_data_consistency_for_event_bool_convertion
+  puts ''.ljust 80, '*'
+  puts 'checking of data consistency'.center 80
+  puts ''.ljust 80, '*'
+  check = true
+  Mission.where(event: true).each do |mission|
+    check = false if mission.genre != 'event'
+  end
+  check
+end

--- a/lib/tasks/convert_event_bool_in_enum_genre.rake
+++ b/lib/tasks/convert_event_bool_in_enum_genre.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# This namespace contain all tasks who adapt the data at changements of db structure
-namespace :convertion do # rubocop:disable Metrics/BlockLength
-  desc 'it set enum genre at event for mission who have the event boolean at true'
-  task convert_event_bool_in_enum_genre: :environment do
+# This namespace contains all tasks that adapt existing data when the DB structure changes
+namespace :conversion do # rubocop:disable Metrics/BlockLength
+  desc 'it sets the :genre enum to the value of 2 (= event) for missions that have the :event boolean attribute set to true'
+  task mission_event_bool_to_genre_enum: :environment do
     puts ''.ljust 80, '*'
     puts 'start migration'.center 80
     puts ''.ljust 80, '*'

--- a/spec/requests/admin/missions_spec.rb
+++ b/spec/requests/admin/missions_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'A Missions admin request', type: :request do
     context 'when the :genre params is set to event' do
       let(:mission_params) { attributes_for :mission, genre: 'event', author_id: current_admin.id }
 
-      it 'creates the mission with the genre setted to event' do
+      it 'creates the mission with the genre set to event' do
         post_mission
 
         expect(Mission.last[:genre]).to eq 'event'

--- a/spec/requests/admin/missions_spec.rb
+++ b/spec/requests/admin/missions_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'A Missions admin request', type: :request do
-  before { sign_in create :member, :super_admin }
+  let(:current_admin) { create :member, :super_admin }
+
+  before { sign_in current_admin }
 
   describe '#generate_schedule' do
     subject(:post_generate_schedule) { post generate_schedule_admin_missions_path(3) }
@@ -19,6 +21,20 @@ RSpec.describe 'A Missions admin request', type: :request do
         follow_redirect!
 
         expect(response.body).to include(I18n.t('admin.missions.generate_schedule.schedule_already_generated'))
+      end
+    end
+  end
+
+  describe 'POST' do
+    subject(:post_mission) { post admin_missions_path, params: { mission: mission_params } }
+
+    context 'when the :genre params is set to event' do
+      let(:mission_params) { attributes_for :mission, genre: 'event', author_id: current_admin.id }
+
+      it 'creates the mission with the genre setted to event' do
+        post_mission
+
+        expect(Mission.last[:genre]).to eq 'event'
       end
     end
   end


### PR DESCRIPTION
We need admins to be able to edit the `:genre` attributes of Mission records.
Since the role of the `:event` attribute has now been taken by the `:genre` enum, we also need to convert existing records to use this `:genre` attribute.

* add Mission `:genre` management in admin views
* the `conversion:mission_event_bool_to_genre_enum` task will convert existing mission records' `:event` boolean to `:genre` enum