### PR TITLE
fix_bug_on_merge_enrolls_in_recruiter_service

### DIFF
--- a/app/services/static_members_recruiter.rb
+++ b/app/services/static_members_recruiter.rb
@@ -53,7 +53,7 @@ class StaticMembersRecruiter
                                            end_time: enrollments.last.end_time,
                                            mission_id: enrollments.first.mission_id,
                                            member_id: enrollments.first.member_id)
-    enrollments.destroy_all if enrollment_created
+    enrollments.where('id != ?', enrollment_created.id).destroy_all if enrollment_created
   end
 
   def enrollments_for_one_static_slot(member, static_slot)

--- a/spec/models/static_members_recruiter_service_spec.rb
+++ b/spec/models/static_members_recruiter_service_spec.rb
@@ -5,17 +5,47 @@ require 'rails_helper'
 RSpec.describe StaticMembersRecruiter, type: :model do
   subject(:static_members_recruite) { StaticMembersRecruiter.new.call }
 
-  let(:static_slot) { create :static_slot, week_day: 'Monday', week_type: 'A', start_time: DateTime.new(2021, 1, 4, 9) }
   let(:member) { create :member }
 
   before { allow(DateTime).to receive(:current).and_return DateTime.new(2020, 12, 10) }
 
-  it 'enroll members with static slot to a corresponding mission' do
-    mission = create :mission, start_date: DateTime.new(2021, 1, 4, 9), genre: 'regulated'
-    member_static_slot = create :member_static_slot, member: member, static_slot: static_slot
+  context 'when the member has one :static_slot corresponding to the mission' do
+    let(:create_static_slot_and_enroll_member_that_one) do
+      static_slot = create :static_slot, week_day: 'Monday', week_type: 'A', start_time: DateTime.new(2021, 1, 4, 9)
+      create :member_static_slot, member: member, static_slot: static_slot
+    end
 
-    static_members_recruite
+    it 'enroll members with :static_slot to this mission' do
+      create_static_slot_and_enroll_member_that_one
+      mission = create :mission, start_date: DateTime.new(2021, 1, 4, 9), genre: 'regulated'
 
-    expect(mission.members).to include(member_static_slot.member)
+      static_members_recruite
+
+      expect(mission.members).to include(member)
+    end
+  end
+
+  context 'when the member has two :static_slots corresponding to the mission' do
+    let(:create_static_slots_and_enroll_member_those_there) do
+      static_slots = []
+      static_slots << (create :static_slot, week_day: 'Monday', week_type: 'A', start_time: DateTime.new(2021, 1, 4, 9))
+      static_slots << (create :static_slot,
+                              week_day: 'Monday',
+                              week_type: 'A',
+                              start_time: DateTime.new(2021, 1, 4, 10, 30))
+
+      static_slots.each do |static_slot|
+        create :member_static_slot, member: member, static_slot: static_slot
+      end
+    end
+
+    it 'enroll members with :static_slots to this mission' do
+      mission = create :mission, start_date: DateTime.new(2021, 1, 4, 9), genre: 'regulated'
+      create_static_slots_and_enroll_member_those_there
+
+      static_members_recruite
+
+      expect(mission.members).to include(member)
+    end
   end
 end

--- a/spec/models/static_members_recruiter_service_spec.rb
+++ b/spec/models/static_members_recruiter_service_spec.rb
@@ -3,30 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe StaticMembersRecruiter, type: :model do
-  subject(:static_members_recruite) { StaticMembersRecruiter.new.call }
+  subject(:recruit_static_members) { StaticMembersRecruiter.new.call }
 
   let(:member) { create :member }
 
   before { allow(DateTime).to receive(:current).and_return DateTime.new(2020, 12, 10) }
 
-  context 'when the member has one :static_slot corresponding to the mission' do
-    let(:create_static_slot_and_enroll_member_that_one) do
+  context 'when the member has one static_slot corresponding to a mission' do
+    let(:create_static_slot_and_enroll_a_member_on_it) do
       static_slot = create :static_slot, week_day: 'Monday', week_type: 'A', start_time: DateTime.new(2021, 1, 4, 9)
       create :member_static_slot, member: member, static_slot: static_slot
     end
 
-    it 'enroll members with :static_slot to this mission' do
-      create_static_slot_and_enroll_member_that_one
+    it 'enrolls members having this static_slot to this mission' do
+      create_static_slot_and_enroll_a_member_on_it
       mission = create :mission, start_date: DateTime.new(2021, 1, 4, 9), genre: 'regulated'
 
-      static_members_recruite
+      recruit_static_members
 
       expect(mission.members).to include(member)
     end
   end
 
-  context 'when the member has two :static_slots corresponding to the mission' do
-    let(:create_static_slots_and_enroll_member_those_there) do
+  context 'when the member has two static_slots corresponding to a mission' do
+    let(:create_two_static_slots_and_enroll_a_member_on_those) do
       static_slots = []
       static_slots << (create :static_slot, week_day: 'Monday', week_type: 'A', start_time: DateTime.new(2021, 1, 4, 9))
       static_slots << (create :static_slot,
@@ -39,11 +39,11 @@ RSpec.describe StaticMembersRecruiter, type: :model do
       end
     end
 
-    it 'enroll members with :static_slots to this mission' do
+    it 'enrolls members having this static_slot to this mission' do
       mission = create :mission, start_date: DateTime.new(2021, 1, 4, 9), genre: 'regulated'
-      create_static_slots_and_enroll_member_those_there
+      create_two_static_slots_and_enroll_a_member_on_those
 
-      static_members_recruite
+      recruit_static_members
 
       expect(mission.members).to include(member)
     end


### PR DESCRIPTION
#### Problem
When a member had two `StaticSlots` that are active on one mission, the `StaticMemberRecruiter` service didn't work.

#### Cause
`StaticMemberRecruiter#merge_enrolls` also destroyed the `Enrollment` created from this operation: the `enrollments` argument containing the filtered relation would auto-update and then also fetch the newly created `Enrollment` when called again

#### Fix
Add a `where` clause on the passed `enrollments`  in order to exclude this `Enrollment` from the destroy query.