### PR TITLE
Add task for set mission to regulated

### DIFF
--- a/lib/tasks/set_missions_to_regulated.rake
+++ b/lib/tasks/set_missions_to_regulated.rake
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# This namespace contains all tasks related to the mission model
+namespace :mission do # rubocop:disable Metrics/BlockLength
+  desc "set futur mission with the :name 'permanence clac' to :regulated"
+  task set_missions_to_regulated: :environment do
+    missions = Mission.where('start_date > ? and genre = ? and name = ?',
+                             DateTime.current + 1.day,
+                             0,
+                             'permanence clac')
+    missions.each do |mission|
+      unless match_all_enrollment_a_time_slot?(mission)
+        puts("the mission at #{mission.start_date} has not been setted, an enrollment mismatch the mission's timeslots")
+        next
+      end
+
+      puts("the mission at #{mission.start_date} has been setted") if mission.update(genre: 1)
+    end
+  end
+
+  def match_all_enrollment_a_time_slot?(mission)
+    mission.enrollments.each do |enrollment|
+      return false unless ((enrollment.end_time.to_i - enrollment.start_time.to_i) % (60 * 90)).zero?
+      return false unless match_a_time_slot?(mission, enrollment)
+    end
+    true
+  end
+
+  def match_a_time_slot?(mission, enrollment)
+    current_time_slot = mission.start_date
+    while current_time_slot < mission.due_date
+      return true if current_time_slot == enrollment.start_time
+
+      current_time_slot += 90.minutes
+    end
+    false
+  end
+end

--- a/spec/lib/set_missions_to_regulated_spec.rb
+++ b/spec/lib/set_missions_to_regulated_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+Rake.application.rake_require 'tasks/set_missions_to_regulated'
+
+RSpec.describe 'mission:set_missions_to_regulated', type: :feature do
+  before do
+    allow(DateTime).to receive(:current).and_return DateTime.new(2020, 12, 10, 10)
+  end
+
+  let(:mission) { create :mission, name: 'permanence clac', start_date: DateTime.current + 2.days }
+
+  it "set future missions with name 'permanence clac' and genre 'standard' to regulated" do
+    mission # create mission
+
+    Rake::Task['mission:set_missions_to_regulated'].execute
+
+    expect(mission.reload.genre).to eq 'regulated'
+  end
+
+  context "when an enrollment of the mission is not matching the mission 's timeslots" do
+    let(:create_enrollment) do
+      create :enrollment,
+             start_time: mission.start_date + 1.hour,
+             end_time: mission.due_date + 2.5.hours,
+             mission_id: mission.id
+    end
+
+    it "doesn't update the mission" do
+      create_enrollment
+
+      Rake::Task['mission:set_missions_to_regulated'].execute
+
+      expect(mission.reload.genre).not_to eq 'regulated'
+    end
+  end
+
+  context 'when an enrollment of the mission have not a duration which is a multiple of 90 minutes' do
+    let(:create_enrollment) do
+      create :enrollment,
+             start_time: mission.start_date + 1.hour,
+             end_time: mission.due_date,
+             mission_id: mission.id
+    end
+
+    it "doesn't update the mission" do
+      create_enrollment
+
+      Rake::Task['mission:set_missions_to_regulated'].execute
+
+      expect(mission.reload.genre).not_to eq 'regulated'
+    end
+  end
+end


### PR DESCRIPTION
it set future mission which are
  -name: 'permanence clac'
  -genre: 'standard'
  -with enrollments are matching timeslots