### PR TITLE
Fix calculation of #monthly_worked_hours

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -26,6 +26,14 @@ class Enrollment < ApplicationRecord
   validates_with EnrollmentValidators::DurationValidator
   validates_with EnrollmentValidators::MatchingMissionTimeSlotsValidator
 
+  scope :has_worked_this_month, lambda { |date|
+    joins(:mission)
+      .where(missions: {
+               start_date: (date.beginning_of_month)..(date.end_of_month)
+             })
+      .where.not(missions: { genre: 'event' })
+  }
+
   def duration
     return 0 if start_time.nil? || end_time.nil?
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -81,10 +81,8 @@ class Member < ApplicationRecord
   # @return [Float]
   # @param date [Date]
   def monthly_worked_hours(date)
-    month_number = date.month
-    family_enrollments
-      .select { |enroll| (enroll.mission.start_date.month == month_number && enroll.mission.genre != 'event') }
-      .reduce(0.0) { |sum, enrollment| sum + enrollment.duration }
+    family_enrollments.has_worked_this_month(date)
+                      .reduce(0.0) { |sum, enrollment| sum + enrollment.duration }
   end
 
   def redactor?
@@ -110,6 +108,7 @@ class Member < ApplicationRecord
   def family_enrollments
     return enrollments if register_id.nil?
 
-    Member.includes(:enrollments, enrollments: :mission).where(register_id: register_id).map(&:enrollments).flatten
+    Enrollment.joins(:member)
+              .where(members: { register_id: register_id })
   end
 end

--- a/spec/factories/enrollments.rb
+++ b/spec/factories/enrollments.rb
@@ -13,7 +13,6 @@
 
 FactoryBot.define do
   factory :enrollment do
-
     association :mission
     association :member
 


### PR DESCRIPTION
The calculation would only check for a given month, independently from
the years value. E.g. a mission done on 2020-10-31 would be counted
for a #monthly_worked_hours call with a date of 2021-10-31.

* Optimize query to maximize DB operations and minimize RAM usage
* Query only for the month of the given date