### PR TITLE
Fix validation bug on missions update #338

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -22,7 +22,7 @@ class Enrollment < ApplicationRecord
   validates_with EnrollmentValidators::CashRegisterProficiencyValidator
   validates_with EnrollmentValidators::DatetimesInclusionValidator
   validates_with EnrollmentValidators::UniquenessEnrollmentValidator, on: :create
-  validates_with EnrollmentValidators::AvailabilityPlaceValidator
+  validates_with EnrollmentValidators::AvailabilityPlaceValidator, on: :create
   validates_with EnrollmentValidators::AvailabilitySlotValidator
   validates_with EnrollmentValidators::DurationValidator
   validates_with EnrollmentValidators::MatchingMissionTimeSlotsValidator

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -72,7 +72,7 @@ class Member < ApplicationRecord
   before_validation :set_unique_display_name
 
   enum role: { member: 0, admin: 1, super_admin: 2 }
-  enum cash_register_proficiency: { untrained: 0, beginner: 1, proficient: 2 }
+  enum cash_register_proficiency: { untrained: 0,newbie: 1, beginner: 2, proficient: 3 }
 
   def thredded_admin?
     admin? || super_admin?

--- a/app/transactions/members/update_transaction.rb
+++ b/app/transactions/members/update_transaction.rb
@@ -65,7 +65,7 @@ module Members
     end
 
     def update_member(input)
-      Failure(t('activerecord.errors.messages.update_fail')) unless @current_member.update(@member_params)
+      Failure(I18n.t 'activerecord.errors.messages.update_fail') unless @current_member.update(@member_params)
 
       Success(input)
     end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,10 @@
 fr:
   activerecord:
     errors:
+      models:
+        static_slot:
+          messages:
+            selection_save_failure: error 
       messages:
         creation_fail: La création de %{model} a échoué
         destroy_fail: La suppression de %{model} a échoué
@@ -48,6 +52,7 @@ fr:
         cash_register_proficiency: Formation à la caisse
         cash_register_proficiencies:
           untrained: non formé à la caisse
+          newbie: nouveau
           beginner: débutant à la caisse
           proficient: formé à la caisse
         email: E-mail

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Enrollment, type: :model do
     end
   end
 
+  describe 'validations' do
+    context 'when a new enrollment is created where mission is full' do
+      it 'raises an error' do
+        mission =  create :mission, max_member_count: 4 
+        enroll_n_members_on_mission(mission, 4)
+        extra_enrollment = Enrollment.new(mission: mission)
+
+        expect(extra_enrollment).to_not be_valid
+      end
+    end
+  end
+
   describe '#duration' do
     subject(:create_enrollment) do
       create :enrollment, start_time: mission.start_date, end_time: mission.start_date + 2.hours, mission: mission
@@ -56,6 +68,17 @@ RSpec.describe Enrollment, type: :model do
 
         expect(enrollment.duration).to eq 1.5
       end
+    end
+  end
+
+  def enroll_n_members_on_mission(mission, members_count)
+    members = create_list :member, members_count
+    members.each do |member|
+      create :enrollment,
+             member: member,
+             mission: mission,
+             start_time: mission.start_date,
+             end_time: mission.start_date + 3.hours
     end
   end
 end

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -26,11 +26,19 @@ RSpec.describe Enrollment, type: :model do
   end
 
   describe 'validations' do
-    context 'when a new enrollment is created where mission is full' do
-      it 'raises an error' do
-        mission =  create :mission, max_member_count: 4 
-        enroll_n_members_on_mission(mission, 4)
-        extra_enrollment = Enrollment.new(mission: mission)
+    context 'when a new enrollment is created on a full mission' do
+      let(:full_mission) do
+        create :mission, max_member_count:4 do |mission|
+          create_list :enrollment,
+                       4, 
+                       mission: mission,
+                       start_time: mission.start_date,
+                       end_time: mission.start_date + 3.hours
+        end
+      end
+
+      it 'the enrollment is invalid' do
+        extra_enrollment = Enrollment.new(mission: full_mission)
 
         expect(extra_enrollment).to_not be_valid
       end
@@ -68,17 +76,6 @@ RSpec.describe Enrollment, type: :model do
 
         expect(enrollment.duration).to eq 1.5
       end
-    end
-  end
-
-  def enroll_n_members_on_mission(mission, members_count)
-    members = create_list :member, members_count
-    members.each do |member|
-      create :enrollment,
-             member: member,
-             mission: mission,
-             start_time: mission.start_date,
-             end_time: mission.start_date + 3.hours
     end
   end
 end


### PR DESCRIPTION
Issue:
The enrollments validator was raising an AvailabilityPlaceValidator error when enrollments were updated. Only this issue from the ticket is being addressed here due to priority.

Implemented changes:
The AvailabilityPlaceValidator  scope has been changed to on: create, as that is the only time it is helpful to check if the max_member_count condition has been reached. 