### PR TITLE
Shipping missions

### DIFF
--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -30,7 +30,7 @@ class EnrollmentsController < ApplicationController
 
   # @return [ActionController::Parameters] The filtered parameters for enrollment.
   def permitted_params
-    if @mission.genre == 'regulated'
+    if @mission.regulated?
       params.require(:enrollment).permit(:member_id, :mission_id, time_slots: [])
     else
       params.require(:enrollment).permit(:member_id, :mission_id, :start_time, :end_time)

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -37,7 +37,7 @@ class Enrollment < ApplicationRecord
       .where(missions: {
                start_date: (date.beginning_of_month)..(date.end_of_month)
              })
-      .where.not(missions: {genre: 'event'})
+      .where.not(missions: {genre: :event})
   }
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -23,7 +23,8 @@ class Enrollment < ApplicationRecord
   before_validation :set_defaults
   before_validation :synchronise_date_info_with_parent_mission
 
-  validates_with Enrollments::CashRegisterProficiencyValidator
+  validates_with Enrollments::CashRegisterProficiencyValidator,
+                 if: proc { mission.standard? || mission.regulated? }
   validates_with Enrollments::DurationValidator
   validates_with Enrollments::MemberUniquenessValidator, on: :create
   validates_with Enrollments::Mission90minTimeSlotsMatchValidator # regulated missions

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -82,7 +82,7 @@ class Mission < ApplicationRecord
   # @param [Member, nil] member If present, also returns enrolled time slots of this member.
   # @return [Array<DateTime>, nil] An array of selectable time slot start times, or nil if the mission is not regulated.
   def selectable_time_slots(member = nil)
-    return nil unless genre == 'regulated'
+    return nil unless regulated?
 
     time_slots = []
     current_time_slot = start_date

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -47,7 +47,7 @@ class Mission < ApplicationRecord
   accepts_nested_attributes_for :addresses, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :enrollments, reject_if: :all_blank, allow_destroy: true
 
-  enum :genre, {standard: 0, regulated: 1, event: 2}
+  enum :genre, {standard: 0, regulated: 1, event: 2, shipping: 3}
 
   attr_accessor :recurrence_rule, :recurrence_end_date, :recurrent_change
 

--- a/app/validators/mission_validators/duration_validator.rb
+++ b/app/validators/mission_validators/duration_validator.rb
@@ -26,7 +26,7 @@ module MissionValidators
     end
 
     def duration_multiple(mission)
-      return true if mission.genre != 'regulated'
+      return true unless mission.regulated?
       return true if ((mission.duration / 60).round % 90).zero?
 
       mission.errors.add :duration, I18n.t('activerecord.errors.models.mission.attributes.duration.multiple')

--- a/app/validators/mission_validators/duration_validator.rb
+++ b/app/validators/mission_validators/duration_validator.rb
@@ -4,7 +4,7 @@ module MissionValidators
   class DurationValidator < ActiveModel::Validator # rubocop:disable Style/Documentation
     def validate(mission)
       return false if mission.start_date.nil? || mission.due_date.nil?
-      return true if mission.genre == 'event'
+      return true if mission.event?
 
       duration_valid?(mission)
     end

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -57,7 +57,7 @@
         </div>
       <% end %>
 
-      <% if @mission.genre == 'regulated' %>
+      <% if @mission.regulated? %>
         <div class="progress-wrapper mt-4">
           <h3 class="progress-label text-capitalize text-md strong-600">
             <%= translate 'activerecord.attributes.mission.cash_register_close_out_required' %> :

--- a/config/locales/models/mission.en.yml
+++ b/config/locales/models/mission.en.yml
@@ -13,6 +13,7 @@ en:
         genres:
           event: Event
           regulated: Regulated
+          shipping: Shipping
           standard: Standard
         max_member_count: maximum member count
         members: Participants

--- a/config/locales/models/mission.en.yml
+++ b/config/locales/models/mission.en.yml
@@ -4,7 +4,7 @@ en:
       mission:
         author: Author
         cash_register_close_out_required: Cash register close out required
-        delivery_expected: Deliery expected
+        delivery_expected: Delivery expected
         description: Description
         due_date: Due date
         duration: duration

--- a/config/locales/models/mission.fr.yml
+++ b/config/locales/models/mission.fr.yml
@@ -13,6 +13,7 @@ fr:
         genres:
           event: Événement
           regulated: Régulée
+          shipping: Livraison
           standard: Standard
         max_member_count: Nombre maximum de participants
         members: Participants

--- a/config/locales/models/mission.fr.yml
+++ b/config/locales/models/mission.fr.yml
@@ -11,7 +11,7 @@ fr:
         enrollments: Participations
         event: Évènement
         genres:
-          event: Événement
+          event: Évènement
           regulated: Régulée
           shipping: Livraison
           standard: Standard

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -50,9 +50,6 @@ RSpec.describe Enrollment, type: :model do
         expect(has_worked_this_month.count).to eq 0
       end
     end
-
-    it 'returns' do
-    end
   end
 
   describe 'instanciation' do

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Enrollment, type: :model do
         create(:enrollment, start_time: mission.start_date, end_time: mission.start_date + 1.5.hours, mission: mission)
       end
 
-      it 'rounds off the dureation to one decimal' do
+      it 'rounds off the duration to one decimal' do
         enrollment = create_enrollment
 
         expect(enrollment.duration).to eq 1.5

--- a/spec/models/enrollment_spec.rb
+++ b/spec/models/enrollment_spec.rb
@@ -16,12 +16,52 @@
 require 'rails_helper'
 
 RSpec.describe Enrollment, type: :model do
+  describe '.has_worked_this_month' do
+    subject(:has_worked_this_month) { described_class.has_worked_this_month Date.current }
+
+    context 'with enrollments on :standard Missions' do
+      let!(:setup) { create(:mission, genre: :standard) { |mission| create(:enrollment, mission:) } }
+
+      it 'returns them' do
+        expect(has_worked_this_month.count).to eq 1
+      end
+    end
+
+    context 'with enrollments on :regulated Missions' do
+      let!(:setup) { create(:mission, genre: :regulated) { |mission| create(:enrollment, mission:) } }
+
+      it 'returns them' do
+        expect(has_worked_this_month.count).to eq 1
+      end
+    end
+
+    context 'with enrollments on :shipping Missions' do
+      let!(:setup) { create(:mission, genre: :shipping) { |mission| create(:enrollment, mission:) } }
+
+      it 'returns them' do
+        expect(has_worked_this_month.count).to eq 1
+      end
+    end
+
+    context 'with enrollments on :event Missions' do
+      let!(:setup) { create(:mission, genre: :event) { |mission| create(:enrollment, mission:) } }
+
+      it 'does not return them' do
+        expect(has_worked_this_month.count).to eq 0
+      end
+    end
+
+    it 'returns' do
+    end
+  end
+
   describe 'instanciation' do
-    let(:enrollment) { create :enrollment }
+    let(:enrollment) { create(:enrollment) }
 
     it 'set :start_time default value to the associated mission start' do
       expect(enrollment.start_time.strftime('%T')).to eq enrollment.mission.start_date.strftime('%T')
     end
+
     it 'set :end_time default value to the associated mission end' do
       expect(enrollment.end_time.strftime('%T')).to eq enrollment.mission.due_date.strftime('%T')
     end
@@ -29,10 +69,10 @@ RSpec.describe Enrollment, type: :model do
 
   describe '#duration' do
     subject(:create_enrollment) do
-      create :enrollment, start_time: mission.start_date, end_time: mission.start_date + 2.hours, mission: mission
+      create(:enrollment, start_time: mission.start_date, end_time: mission.start_date + 2.hours, mission: mission)
     end
 
-    let(:mission) { create :mission }
+    let(:mission) { create(:mission) }
 
     it 'gives the duration of an enrollment in hours' do
       enrollment = create_enrollment
@@ -50,7 +90,7 @@ RSpec.describe Enrollment, type: :model do
 
     context 'when the duration is not equal to a natural number' do
       subject(:create_enrollment) do
-        create :enrollment, start_time: mission.start_date, end_time: mission.start_date + 1.5.hours, mission: mission
+        create(:enrollment, start_time: mission.start_date, end_time: mission.start_date + 1.5.hours, mission: mission)
       end
 
       it 'rounds off the dureation to one decimal' do

--- a/spec/validators/enrollments/cash_register_proficiency_validator_spec.rb
+++ b/spec/validators/enrollments/cash_register_proficiency_validator_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Enrollments::CashRegisterProficiencyValidator do
   context 'with an enrollment not associated with a member' do
     subject(:enrollment) { build(:enrollment, :on_first_time_slot, member: nil) }
 
-    it { is_expected.to be_invalid }
+    it { is_expected.not_to be_valid }
   end
 
   context 'when filling all available enrollment slots of a mission at once' do

--- a/spec/validators/enrollments/cash_register_proficiency_validator_spec.rb
+++ b/spec/validators/enrollments/cash_register_proficiency_validator_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Enrollments::CashRegisterProficiencyValidator do
     end
 
     context 'with a new enrollment of a trained member' do
-      subject(:enroll) do
+      subject(:enrollment) do
         member = create(:member, cash_register_proficiency: :beginner)
         build(:enrollment, mission:, member:)
       end

--- a/spec/validators/enrollments/cash_register_proficiency_validator_spec.rb
+++ b/spec/validators/enrollments/cash_register_proficiency_validator_spec.rb
@@ -38,6 +38,28 @@ RSpec.describe Enrollments::CashRegisterProficiencyValidator do
       it_behaves_like 'a model without missing validation error translations' do
         let(:resource) { enrollment }
       end
+
+      context 'with an :event mission' do
+        let(:mission) do
+          create(:mission, genre: :event, max_member_count: 4) do |mission|
+            members = create_list(:member, 3, cash_register_proficiency: :untrained)
+            mission.enrollments = members.map { |member| create(:enrollment, member:, mission:) }
+          end
+        end
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'with a :shipping mission' do
+        let(:mission) do
+          create(:mission, genre: :shipping, max_member_count: 4) do |mission|
+            members = create_list(:member, 3, cash_register_proficiency: :untrained)
+            mission.enrollments = members.map { |member| create(:enrollment, member:, mission:) }
+          end
+        end
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'with a new enrollment of a trained member' do


### PR DESCRIPTION
New `:shipping` Mission type, that should be counted in the 3hours/month accounting, but should not validate any cash register proficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Shipping" mission type with English and French labels across the app.

* **Behavior Changes**
  * Cash register proficiency is now required only for Standard and Regulated missions.

* **Bug Fixes**
  * Fixed "Delivery expected" typo and adjusted French mission label for Event.

* **Tests**
  * Added and updated tests to cover Shipping mission scenarios and related enrollment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->